### PR TITLE
fix: support multiple lambdas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 virt/
 .tox/
 build/
+__pycache__
 thunk_dict.egg-info/

--- a/thunk_dict/ThunkDict.py
+++ b/thunk_dict/ThunkDict.py
@@ -9,12 +9,10 @@ class ThunkDict(collections.abc.MutableMapping):
         def release(self):
             return self.value()
 
-        def __call__(self, item):
+        def __init__(self, item):
             self.value = item
-            return self
 
     def __init__(self, dictionary=None, *args, **kwargs):
-        self.__lazy__wrapper__ = self.__LazyInternal__()
         self.__dictionary__ = None
 
         if isinstance(dictionary, dict):
@@ -54,7 +52,7 @@ class ThunkDict(collections.abc.MutableMapping):
 
     def __thunk__(self, item):
         if callable(item):
-            return self.__lazy__wrapper__(item)
+            return self.__LazyInternal__(item)
         return item
 
     def __dethunk__(self, item):

--- a/thunk_dict/tests/tests.py
+++ b/thunk_dict/tests/tests.py
@@ -29,6 +29,14 @@ class TestInit(unittest.TestCase):
         with self.assertRaises(TypeError):
             test_dict = ThunkDict("not a dictionary")
 
+    def test_init_with_dict_comprehension(self):
+        test_dict = ThunkDict({
+            num: lambda _num=num: _num * 10 for num in range(3)
+        })
+        self.assertEqual(test_dict[0], 0)
+        self.assertEqual(test_dict[1], 10)
+        self.assertEqual(test_dict[2], 20)
+
 
 class TestDictMethods(unittest.TestCase):
     def test_keys(self):
@@ -70,14 +78,14 @@ class TestDictMethods(unittest.TestCase):
 class TestThunkInit(unittest.TestCase):
     def test(self):
         test_dict = ThunkDict()
-        thunk = test_dict.__lazy__wrapper__(test_constants.calling_function)
+        thunk = test_dict.__LazyInternal__(test_constants.calling_function)
         self.assertIsInstance(thunk, test_dict.__LazyInternal__)
 
 
 class TestDethunk(unittest.TestCase):
     def test(self):
         test_dict = ThunkDict()
-        thunk = test_dict.__lazy__wrapper__(test_constants.calling_function)
+        thunk = test_dict.__LazyInternal__(test_constants.calling_function)
         dethunked = test_dict.__dethunk__(thunk)
         self.assertEqual(dethunked, test_constants.additional_callback)
 
@@ -121,3 +129,6 @@ class TestSetAndGet(unittest.TestCase):
         # Ensure that double access does not accidently call additional_callback
         self.assertEqual(test_dict["key1"],
                          test_constants.additional_callback)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Until now, all lambdas within the same `ThunkDict` were the same.

This was happening:

```python
>>> a=ThunkDict()
>>> a[0] = lambda: 0
>>> a[1] = lambda: 1
>>> a[0]
1
>>> a[1]
1
```

Now, after this fix:

```python
>>> a=ThunkDict()
>>> a[0] = lambda: 0
>>> a[1] = lambda: 1
>>> a[0]
0
>>> a[1]
1
```

The patch includes some changes to make tests actually be executed when running `python -m thunk_dict.tests.tests`, because that's what's configured in tox, but it wasn't actually testing anything.

@moduon MT-8282